### PR TITLE
Use TimeLib.h instead of Time.h

### DIFF
--- a/Example/REBL_UI_Example/REBL_UI_Example.ino
+++ b/Example/REBL_UI_Example/REBL_UI_Example.ino
@@ -1,6 +1,6 @@
 #include "REBL_UI.h"
 #include <LiquidCrystal_SPI_8Bit.h>
-#include <Time.h>
+#include <TimeLib.h>
 
 #define ENCODER_INTERRUPT_PIN 2
 #define ENCODER_B_PIN 4

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Blocking functions could simply return true at the end.
 
 #include "REBL_UI.h"
 #include <LiquidCrystal_SPI_8Bit.h>
-#include <Time.h>
+#include <TimeLib.h>
 
 #define ENCODER_INTERRUPT_PIN 2
 #define ENCODER_B_PIN 4

--- a/REBL_Functions.h
+++ b/REBL_Functions.h
@@ -15,7 +15,7 @@
 #include "REBLMenu.h"
 
 
-#include "Time.h"
+#include "TimeLib.h"
 
 
 #define LEAP_YEAR(Y)     ( ((1970+Y)>0) && !((1970+Y)%4) && ( ((1970+Y)%100) || !((1970+Y)%400) ) )


### PR DESCRIPTION
Recent toolchain versions contain a file named time.h. On case-insensitive operating system like Windows, the #include <Time.h> directive matches this file rather than the intended Time library file, which causes compilation to fail. To resolve this, the Time library header file has been renamed TimeLib.h.

Fixes https://github.com/delta-G/REBL_UI/issues/1

CC: @adamaero